### PR TITLE
feat: add 2024 as-of labels to fund and coal metrics

### DIFF
--- a/app/components/CompanyTable.vue
+++ b/app/components/CompanyTable.vue
@@ -523,7 +523,7 @@ const proColumns: TableColumn<CompanyData>[] = [
   },
   {
     accessorKey: '燃煤使用量（公噸）',
-    header: ({ column }) => createSortableHeader(column, '燃煤使用量（公噸）', 'right'),
+    header: ({ column }) => createSortableHeader(column, '2024 燃煤使用量（公噸）', 'right'),
     enableSorting: true,
     sortingFn: numericSortingFn,
     cell: ({ row }) => h('div', { class: 'text-right' },

--- a/app/components/company/CompanyMetricsTable.vue
+++ b/app/components/company/CompanyMetricsTable.vue
@@ -122,13 +122,13 @@ const allMetrics = computed(() => [
     tooltip: undefined
   },
   {
-    label: '燃煤使用量（公噸）',
+    label: '2024 年燃煤使用量（公噸）',
     value: formatCoalUsage(props.company['燃煤使用量（公噸）']),
     isNegative: false,
     isPositive: false
   },
   {
-    label: '用煤佔全台製造業比例',
+    label: '2024 年用煤佔全台製造業比例',
     value: props.company['用煤佔全台製造業比例'] || '-',
     isNegative: false,
     isPositive: false

--- a/app/pages/funds/[slug]/index.vue
+++ b/app/pages/funds/[slug]/index.vue
@@ -74,6 +74,11 @@ useHead({
       </div>
     </div>
 
+    <!-- Data note -->
+    <p class="text-sm text-earth-brown/80 mt-2">
+      持股快照為 2024 Q4（SITCA 季報）；下表企業排放、用電、燃煤等指標為 2024 全年（環境部年度申報），口徑時點一致。
+    </p>
+
     <!-- Company Table -->
     <div class="mt-8">
       <CompanyTable :rows="companies" :is-pro="false" />

--- a/app/pages/funds/index.vue
+++ b/app/pages/funds/index.vue
@@ -199,8 +199,11 @@ const filteredFunds = computed(() => {
   <div class="space-y-6">
     <div>
       <h1 class="text-3xl sm:text-[2.5rem] font-bold text-green-deep mt-0 sm:mt-8 leading-[1.2] pb-2">投資基金觀測表</h1>
-      <p class="text-earth-brown mb-8">
+      <p class="text-earth-brown mb-2">
         追蹤台灣投資基金的排碳大戶投資狀況
+      </p>
+      <p class="text-sm text-earth-brown/80 mb-8">
+        資料說明：基金持股快照為 2024 Q4（SITCA 季報），燃煤量與排碳量為 2024 全年（環境部年度申報），口徑時點一致。2025 年後新發行的 ETF 暫不納入；待 2025 完整年度資料釋出再更新。
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

- /funds index + fund detail pages now display a data-as-of note: 持股 2024 Q4 (SITCA 季報), 燃煤/排碳 2024 (環境部 年度申報). Same year, no temporal mismatch — but the website previously showed neither, so users defaulted to assuming current.
- Company metrics table: 燃煤使用量（公噸）→ 2024 年燃煤使用量（公噸）; 用煤佔全台製造業比例 → 2024 年用煤佔全台製造業比例.
- /funds pro table (CompanyTable.vue) coal column header: 燃煤使用量（公噸）→ 2024 燃煤使用量（公噸）.

## Background

Companion to a Sheet A SOT refresh that:
1. Replaced 基金 x 排碳大戶 + raw_ETF_資訊彙整 holdings with 2024 Q4 snapshot (was 2026 Q1, mismatched against 2024 coal data).
2. Archived 6 ETFs (009802 / 009803 / 009804 / 009808 / 009809 / 009816) that launched 2025-03 → 2026-01, so no 2024 Q4 holdings disclosure exists.

See observatory project session log: docs/session13-fund-holdings-2024Q4-alignment.md (in 排碳大戶資料修正 04-16 project).

## Test plan

- [ ] Visit /funds — see new data-as-of note under title
- [ ] Visit /funds/00850 — see new data-as-of note above company table; coal column header reads 2024 燃煤使用量（公噸）
- [ ] Visit any company page — metrics table shows 2024 年燃煤使用量（公噸） and 2024 年用煤佔全台製造業比例
- [ ] Verify 6 archived funds (009802 / 009803 / 009804 / 009808 / 009809 / 009816) no longer appear in /funds list

🤖 Generated with [Claude Code](https://claude.com/claude-code)